### PR TITLE
skip storing authkey locally

### DIFF
--- a/tasks/auth.yml
+++ b/tasks/auth.yml
@@ -25,24 +25,17 @@
     timeout=30
   when: inventory_hostname == play_hosts[0]
 
-- name: Fetching /etc/corosync/authkey to /tmp
-  fetch:
+- name: Fetching /etc/corosync/authkey
+  slurp:
     src=/etc/corosync/authkey
-    dest="{{ corosync_tmp_authkey }}"
-    flat=yes
-  run_once: true
-  register: authkey
+    run_once: true
+  register: tmp_authkey
+  when: inventory_hostname == play_hosts[0]
 
 - name: Synchronizing /etc/corosync/authkey everywhere
   copy:
-    src="{{ corosync_tmp_authkey }}"
+    content="{{ tmp_authkey }}"
     dest=/etc/corosync/authkey
     mode=0400
   notify: restart corosync
-
-- name: Cleaning /tmp/authkey file for security reason
-  become: no
-  local_action:
-    file
-      path="{{ corosync_tmp_authkey }}"
-      state=absent
+  when: inventory_hostname not play_hosts[0]

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,4 +2,3 @@
 # file: roles/corosync/vars/main.yml
 corosync_apt_backports: "deb http://ftp.debian.org/debian jessie-backports main"
 corosync_default_release: jessie-backports
-corosync_tmp_authkey: /tmp/authkey


### PR DESCRIPTION
removing the need for creating tmp file, just slurping the key from first and propagating it to other nodes.

corosync_tmp_authkey will be obsolete.